### PR TITLE
Extract scm source json

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -38,7 +38,7 @@
   "Starts the system running, sets the Var #'system."
   []
   (alter-var-root #'system
-                  (constantly (org.zalando.stups.pierone.core/run {:system-log-level "DEBUG"}))))
+                  (constantly (org.zalando.stups.pierone.core/run {:system-stups-log-level "DEBUG"}))))
 
 (defn stop
   "Stops the system if it is currently running, updates the Var

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,11 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.zalando.stups/friboo "0.9.0"]
+                 [org.zalando.stups/friboo "0.11.0"]
 
                  [yesql "0.5.0-rc2"]
                  [org.postgresql/postgresql "9.3-1102-jdbc41"]
+                 [org.apache.commons/commons-compress "1.9"]
 
                  [amazonica "0.3.19"]]
 

--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -13,6 +13,21 @@ produces:
   - application/json
 
 definitions:
+  ScmSourceInformation:
+    type: object
+    properties:
+      url:
+        type: string
+        example: "git:git@github.com:zalando-stups/pierone.git"
+      revision:
+        type: string
+        example: cd768599e1bb41c38279c26254feff5cf57bf967
+      author:
+        type: string
+        example: hjacobs
+      status:
+        type: string
+        example: ""
   TagSummary:
     type: object
     properties:
@@ -381,4 +396,33 @@ paths:
             type: array
             items:
               $ref: "#/definitions/TagSummary"
+
+  /teams/{team}/artifacts/{artifact}/tags/{tag}/scm-source:
+    get:
+      summary: Get scm-source.json
+      description: Get artifact's SCM source information (e.g. GIT commit)
+      tags:
+        - Pier One API
+      operationId: org.zalando.stups.pierone.api/get-scm-source
+      parameters:
+        - name: team
+          in: path
+          required: true
+          type: string
+        - name: artifact
+          in: path
+          required: true
+          type: string
+        - name: tag
+          in: path
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Return scm-source.json
+          schema:
+            $ref: "#/definitions/ScmSourceInformation"
+
+
+
 

--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -12,6 +12,20 @@ consumes:
 produces:
   - application/json
 
+definitions:
+  TagSummary:
+    type: object
+    properties:
+      name:
+        type: string
+        example: "1.0"
+      created:
+        type: string
+        example: 2015-05-07T15:49:51.230+0200
+      created_by:
+        type: string
+        example: hjacobs
+
 paths:
 
   ## Docker Registry API v2
@@ -366,4 +380,5 @@ paths:
           schema:
             type: array
             items:
-              type: string
+              $ref: "#/definitions/TagSummary"
+

--- a/resources/db/migration/V1__Basic_schema.sql
+++ b/resources/db/migration/V1__Basic_schema.sql
@@ -22,6 +22,23 @@ CREATE TABLE images (
   PRIMARY KEY (i_id)
 );
 
+CREATE TABLE scm_source_data (
+  ssd_image_id TEXT NOT NULL,
+
+  ssd_url TEXT NOT NULL,
+
+  ssd_revision TEXT NOT NULL,
+
+  ssd_author TEXT NOT NULL,
+
+  ssd_status TEXT NOT NULL,
+
+  ssd_created timestamp NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (ssd_image_id),
+  FOREIGN KEY (ssd_image_id) REFERENCES images (i_id)
+);
+
 -- base entity: tags
 CREATE TABLE tags (
 --the team ID

--- a/resources/db/migration/V1__Basic_schema.sql
+++ b/resources/db/migration/V1__Basic_schema.sql
@@ -1,35 +1,38 @@
+CREATE SCHEMA zp_data;
+SET search_path TO zp_data;
+
 -- base entity: images
-CREATE TABLE image (
+CREATE TABLE images (
 
 -- the official image ID
-  id       TEXT NOT NULL,
+  i_id       TEXT NOT NULL,
 
 -- the JSON metadata of the image
-  metadata TEXT NOT NULL,
+  i_metadata TEXT NOT NULL,
 
 -- if the image was accepted (image binary and metadata are present)
-  accepted BOOL NOT NULL,
+  i_accepted BOOL NOT NULL,
 
 -- the parent image of this image
-  parent   TEXT,
+  i_parent_id   TEXT,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (i_id)
 );
 
 -- base entity: tags
-CREATE TABLE tag (
+CREATE TABLE tags (
 --the team ID
-  team     TEXT NOT NULL,
+  t_team     TEXT NOT NULL,
 
 -- the artifact name
-  artifact TEXT NOT NULL,
+  t_artifact TEXT NOT NULL,
 
 -- the artifact tag
-  name     TEXT NOT NULL,
+  t_name     TEXT NOT NULL,
 
 -- the referenced image
-  image    TEXT NOT NULL,
+  t_image_id    TEXT NOT NULL,
 
-  PRIMARY KEY (team, artifact, name),
-  FOREIGN KEY (image) REFERENCES image (id)
+  PRIMARY KEY (t_team, t_artifact, t_name),
+  FOREIGN KEY (t_image_id) REFERENCES images (i_id)
 );

--- a/resources/db/migration/V1__Basic_schema.sql
+++ b/resources/db/migration/V1__Basic_schema.sql
@@ -16,6 +16,9 @@ CREATE TABLE images (
 -- the parent image of this image
   i_parent_id   TEXT,
 
+  i_created timestamp NOT NULL DEFAULT now(),
+  i_created_by TEXT,
+
   PRIMARY KEY (i_id)
 );
 
@@ -32,6 +35,9 @@ CREATE TABLE tags (
 
 -- the referenced image
   t_image_id    TEXT NOT NULL,
+
+  t_created timestamp NOT NULL DEFAULT now(),
+  t_created_by TEXT,
 
   PRIMARY KEY (t_team, t_artifact, t_name),
   FOREIGN KEY (t_image_id) REFERENCES images (i_id)

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -4,13 +4,15 @@ SELECT t_team AS team
  GROUP BY t_team;
 
 -- name: list-artifacts
-SELECT t_artifact
+SELECT t_artifact AS artifact
   FROM tags
  WHERE t_team = :team
  GROUP BY t_artifact;
 
 -- name: list-tags
-SELECT t_name
+SELECT t_name AS name,
+       t_created AS created,
+       t_created_by AS created_by
   FROM tags
  WHERE t_team = :team
    AND t_artifact = :artifact;

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -1,16 +1,16 @@
 -- name: list-teams
-SELECT team
-  FROM tag
- GROUP BY team;
+SELECT t_team AS team
+  FROM tags
+ GROUP BY t_team;
 
 -- name: list-artifacts
-SELECT artifact
-  FROM tag
- WHERE team = :team
- GROUP BY artifact;
+SELECT t_artifact
+  FROM tags
+ WHERE t_team = :team
+ GROUP BY t_artifact;
 
 -- name: list-tags
-SELECT name
-  FROM tag
- WHERE team = :team
-   AND artifact = :artifact;
+SELECT t_name
+  FROM tags
+ WHERE t_team = :team
+   AND t_artifact = :artifact;

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -16,3 +16,17 @@ SELECT t_name AS name,
   FROM tags
  WHERE t_team = :team
    AND t_artifact = :artifact;
+
+-- name: get-scm-source
+SELECT ssd_url AS url,
+       ssd_revision AS revision,
+       ssd_author AS author,
+       ssd_status AS status,
+       ssd_created AS created
+  FROM tags
+  JOIN scm_source_data
+    ON ssd_image_id = t_image_id
+ WHERE t_team = :team
+   AND t_artifact = :artifact
+   AND t_name = :tag;
+

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -18,6 +18,14 @@ SELECT t_name AS name,
    AND t_artifact = :artifact;
 
 -- name: get-scm-source
+WITH RECURSIVE ancestry(id, next, path) AS (
+    SELECT i_id, i_parent_id, ARRAY[i_id]
+      FROM zp_data.images
+ UNION ALL
+    SELECT id, i_parent_id, path || i_id
+      FROM zp_data.images, ancestry
+     WHERE i_id = next
+      AND next IS NOT NULL)
 SELECT ssd_url AS url,
        ssd_revision AS revision,
        ssd_author AS author,
@@ -25,8 +33,7 @@ SELECT ssd_url AS url,
        ssd_created AS created
   FROM tags
   JOIN scm_source_data
-    ON ssd_image_id = t_image_id
+    ON ssd_image_id = ANY((SELECT MAX(path) FROM ancestry WHERE id = t_image_id AND next IS NULL)::text[])
  WHERE t_team = :team
    AND t_artifact = :artifact
    AND t_name = :tag;
-

--- a/resources/db/v1.sql
+++ b/resources/db/v1.sql
@@ -32,6 +32,11 @@ UPDATE images
    SET i_accepted = TRUE
  WHERE i_id = :image;
 
+-- name: create-scm-source-data!
+INSERT INTO scm_source_data
+       (ssd_image_id, ssd_url, ssd_revision, ssd_author, ssd_status)
+VALUES (:image, :url, :revision, :author, :status);
+
 -- name: get-image-metadata
 SELECT i_metadata AS metadata
   FROM images

--- a/resources/db/v1.sql
+++ b/resources/db/v1.sql
@@ -1,45 +1,45 @@
 -- name: read-tags
-SELECT name,
-       image
-  FROM tag
- WHERE team = :team
-   AND artifact = :artifact;
+SELECT t_name AS name,
+       t_image_id AS image
+  FROM tags
+ WHERE t_team = :team
+   AND t_artifact = :artifact;
 
 -- name: create-tag!
-INSERT INTO tag
-       (team, artifact, name, image)
+INSERT INTO tags
+       (t_team, t_artifact, t_name, t_image_id)
 VALUES (:team, :artifact, :name, :image);
 
 -- name: update-tag!
-UPDATE tag
-   SET image = :image
- WHERE team = :team
-   AND artifact = :artifact
-   AND name = :name;
+UPDATE tags
+   SET t_image_id = :image
+ WHERE t_team = :team
+   AND t_artifact = :artifact
+   AND t_name = :name;
 
 -- name: create-image!
-INSERT INTO image
-       (id, metadata, accepted, parent)
+INSERT INTO images
+       (i_id, i_metadata, i_accepted, i_parent_id)
 VALUES (:image, :metadata, FALSE, :parent);
 
 -- name: delete-unaccepted-image!
-DELETE FROM image
-WHERE id = :image
-      AND accepted = FALSE;
+DELETE FROM images
+WHERE i_id = :image
+      AND i_accepted = FALSE;
 
 -- name: accept-image!
-UPDATE image
-   SET accepted = TRUE
- WHERE id = :image;
+UPDATE images
+   SET i_accepted = TRUE
+ WHERE i_id = :image;
 
 -- name: get-image-metadata
-SELECT metadata
-  FROM image
- WHERE id = :image
-   AND accepted = TRUE;
+SELECT i_metadata AS metadata
+  FROM images
+ WHERE i_id = :image
+   AND i_accepted = TRUE;
 
 -- name: get-image-parent
-SELECT parent
-  FROM image
- WHERE id = :image
-   AND accepted = TRUE;
+SELECT i_parent_id AS parent
+  FROM images
+ WHERE i_id = :image
+   AND i_accepted = TRUE;

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -29,6 +29,6 @@
 (defn read-tags
   "Lists all tags of an artifact."
   [parameters _ db _]
-  (let [result (map :name (sql/list-tags parameters {:connection db}))]
+  (let [result (sql/list-tags parameters {:connection db})]
     (-> (ring/response result)
         (fring/content-type-json))))

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -36,5 +36,7 @@
 (defn get-scm-source
   "Get SCM source information"
   [parameters _ db _]
-  (-> (ring/response {})
-      (fring/content-type-json)))
+  (let [result (first (sql/get-scm-source parameters {:connection db}))]
+    (-> (ring/response result)
+        (ring/status (if result 200 404))
+        (fring/content-type-json))))

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -32,3 +32,9 @@
   (let [result (sql/list-tags parameters {:connection db})]
     (-> (ring/response result)
         (fring/content-type-json))))
+
+(defn get-scm-source
+  "Get SCM source information"
+  [parameters _ db _]
+  (-> (ring/response {})
+      (fring/content-type-json)))

--- a/src/org/zalando/stups/pierone/api_v1.clj
+++ b/src/org/zalando/stups/pierone/api_v1.clj
@@ -4,8 +4,14 @@
             [ring.util.response :as ring]
             [clojure.data.json :as json]
             [org.zalando.stups.pierone.sql :as sql]
+            [clojure.java.io :as io]
             [org.zalando.stups.pierone.storage :as s])
-  (:import (java.sql SQLException)))
+  (:import (java.sql SQLException)
+
+           (java.util UUID)
+           (org.apache.commons.compress.compressors.gzip GzipCompressorInputStream)
+           (org.apache.commons.compress.archivers.tar TarArchiveInputStream)
+           (java.io FileInputStream File)))
 
 (defn- resp
   "Returns a response including various Docker headers set."
@@ -104,10 +110,31 @@
       (resp "image not found" request :status 404)
       (resp (-> result first :metadata json/read-str) request))))
 
+(defn get-scm-source-data
+  [tmp-file]
+  (try
+    (let [fis (FileInputStream. tmp-file)
+          tar (TarArchiveInputStream. (GzipCompressorInputStream. fis))]
+      (loop []
+        (when-let [entry (.getNextTarEntry tar)]
+          (log/info "Entry: %s" (.getName entry))
+          (recur))))
+    nil
+    (catch Exception e
+      (log/error e "Failed to read image layer")
+      nil)))
+
+
 (defn put-image-binary
   "Stores an image's binary data. Second call in upload sequence."
   [{:keys [image data]} request db storage]
-  (s/write-data storage image data)
+  (let [^File tmp-file (io/file (:directory storage) (str image ".tmp-" (UUID/randomUUID)))]
+    (io/copy data tmp-file)
+    (s/write-data storage image tmp-file)
+    (when-let [scm-source (get-scm-source-data tmp-file)]
+      (log/info "Found scm-source.json in image %s: %s" image scm-source)
+      (sql/create-scm-source-data! (assoc scm-source :image image) {:connection db}))
+    (io/delete-file tmp-file true))
   (sql/accept-image! {:image image} {:connection db})
   (log/info "Stored new image %s." image)
   (resp "OK" request))

--- a/src/org/zalando/stups/pierone/sql.clj
+++ b/src/org/zalando/stups/pierone/sql.clj
@@ -9,7 +9,8 @@
    :db-subprotocol "postgresql"
    :db-subname "//localhost:5432/pierone"
    :db-user "postgres"
-   :db-password "postgres"})
+   :db-password "postgres"
+   :db-init-sql "SET search_path TO zp_data"})
 
 (defqueries "db/pierone.sql")
 (defqueries "db/v1.sql")

--- a/test/org/zalando/stups/pierone/core_test.clj
+++ b/test/org/zalando/stups/pierone/core_test.clj
@@ -53,10 +53,10 @@
 (defn setup []
   (let [system (run {})]
     (doseq [tag all-tags]
-      (jdbc/delete! (:db system) :tag ["team = ? AND artifact = ? AND name = ?" (:team tag) (:artifact tag) (:name tag)])
+      (jdbc/delete! (:db system) :tags ["t_team = ? AND t_artifact = ? AND t_name = ?" (:team tag) (:artifact tag) (:name tag)])
       (println "Deleted tag" (:team tag) "/" (:artifact tag) ":" (:name tag) "from old tests if existed."))
     (doseq [image all-images]
-      (jdbc/delete! (:db system) :image ["id = ?" (:id image)])
+      (jdbc/delete! (:db system) :images ["i_id = ?" (:id image)])
       (println "Deleted image" (:id image) "from old tests if existed."))
     system))
 


### PR DESCRIPTION
- Load scm-source.json from image layer and store it into zp_data.scm_source_data table.
- Allow fetching SCM source information via REST endpoint.

Fixes #8 
