### PR TITLE
Ensure streams are always closed

### DIFF
--- a/src/org/zalando/stups/pierone/api_v1.clj
+++ b/src/org/zalando/stups/pierone/api_v1.clj
@@ -152,8 +152,8 @@
 (defn get-scm-source-data
   [tmp-file]
   (try
-    (let [fis (FileInputStream. tmp-file)
-          tar-stream (TarArchiveInputStream. (GzipCompressorInputStream. fis))]
+    (with-open [fis (FileInputStream. tmp-file)
+                tar-stream (TarArchiveInputStream. (GzipCompressorInputStream. fis))]
       (loop []
         (when-let [entry (.getNextTarEntry tar-stream)]
           (if (= (.getName entry) "scm-source.json")


### PR DESCRIPTION
Even though the tmp-file is deleted afterwards, it might still be better to ensure that the streams are always closed properly.
