### PR TITLE
prohibit latest

### DIFF
--- a/test/org/zalando/stups/pierone/core_test.clj
+++ b/test/org/zalando/stups/pierone/core_test.clj
@@ -33,6 +33,11 @@
    :artifact "kio"
    :name     "1.0"})
 
+(def test-tag-latest
+  {:team     "stups"
+   :artifact "kio"
+   :name     "latest"})
+
 (def test-tag-snapshot
   {:team     "stups"
    :artifact "kio"
@@ -168,6 +173,13 @@
       ; tag -SNAPSHOT image again -> ok
       (expect "tag snapshot again"
               200 (client/put (url "/repositories/" (:team test-tag-snapshot) "/" (:artifact test-tag-snapshot) "/tags/" (:name test-tag-snapshot))
+                              {:body             (str "\"" (:id alternative) "\"")
+                               :content-type     :json
+                               :throw-exceptions false}))
+
+      ; tag latest -> not ok (to avoid mistakenly creating an immutable latest)
+      (expect "tag latest not ok"
+              409 (client/put (url "/repositories/" (:team test-tag-latest) "/" (:artifact test-tag-latest) "/tags/" (:name test-tag-latest))
                               {:body             (str "\"" (:id alternative) "\"")
                                :content-type     :json
                                :throw-exceptions false})))


### PR DESCRIPTION
Allowing the tag "latest" into pierone is not a good idea. "latest" is a common convention in the docker world. But using latest in pierone would create an immutable latest, meaning it is very soon not the latest anymore.

I think it would be best never to allow "latest" as a tag into pierone to avoid such a mistake. This pull request implements such a validation (along with a test)
