### PR TITLE
stats endpoint perf

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.zalando.stups/pierone "0.22.0"
+(defproject org.zalando.stups/pierone "0.23.0-SNAPSHOT"
   :description "Pier One Docker Registry"
   :url "https://github.com/zalando-stups/pierone"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.zalando.stups/pierone "0.22.0-SNAPSHOT"
+(defproject org.zalando.stups/pierone "0.22.0"
   :description "Pier One Docker Registry"
   :url "https://github.com/zalando-stups/pierone"
   :license {:name "Apache License"

--- a/project.clj
+++ b/project.clj
@@ -45,6 +45,7 @@
   :profiles {:uberjar {:aot :all}
 
              :test    {:dependencies [[clj-http "2.0.0"]
+                                      [digest "1.4.4"]
                                       [org.clojure/java.jdbc "0.3.7"]]}
 
              :dev     {:repl-options {:init-ns user}

--- a/resources/db/v1.sql
+++ b/resources/db/v1.sql
@@ -65,14 +65,15 @@ GROUP BY name
 ORDER BY name
 
 -- name: get-image-ancestry
-  WITH RECURSIVE parents(i_id)
-    AS (VALUES (:image)
-         UNION
-        SELECT img.i_parent_id
-          FROM images img, 
-               parents p
-         WHERE img.i_id = p.i_id
-           AND img.i_accepted = TRUE)
-SELECT i_id AS id
-  FROM parents
- WHERE i_id IS NOT NULL
+    WITH RECURSIVE parent(i_id) AS (
+  SELECT i_parent_id
+    FROM zp_data.images i
+   WHERE i.i_id = :image
+   UNION
+  SELECT img.i_id
+    FROM (SELECT *
+            FROM zp_data.images inside
+           WHERE inside.i_id = i_id
+                 AND inside.i_accepted IS TRUE) AS img)
+  SELECT i_id AS id
+    FROM parent;

--- a/resources/db/v1.sql
+++ b/resources/db/v1.sql
@@ -65,15 +65,14 @@ GROUP BY name
 ORDER BY name
 
 -- name: get-image-ancestry
-    WITH RECURSIVE parent(i_id) AS (
-  SELECT i_parent_id
-    FROM zp_data.images i
-   WHERE i.i_id = :image
-   UNION
-  SELECT img.i_id
-    FROM (SELECT *
-            FROM zp_data.images inside
-           WHERE inside.i_id = i_id
-                 AND inside.i_accepted IS TRUE) AS img)
-  SELECT i_id AS id
-    FROM parent;
+  WITH RECURSIVE parents(i_id)
+    AS (VALUES (:image)
+         UNION
+        SELECT img.i_parent_id
+          FROM images img, 
+               parents p
+         WHERE img.i_id = p.i_id
+           AND img.i_accepted = TRUE)
+SELECT i_id AS id
+  FROM parents
+ WHERE i_id IS NOT NULL

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -74,8 +74,9 @@
   (let [conn {:connection db}
         artifacts (map :artifact
                        (sql/cmd-list-artifacts {:team team} conn))
-        tags (apply #(sql/cmd-list-tags {:team team :artifact %} conn)
-                    artifacts)
+        tags (->> artifacts
+                  (map #(sql/cmd-list-tags {:team team :artifact %} conn))
+                  (flatten))
         all-images (or images
                        (sql/cmd-list-images nil conn))
         images (->> tags

--- a/test/org/zalando/stups/pierone/perf_test.clj
+++ b/test/org/zalando/stups/pierone/perf_test.clj
@@ -39,7 +39,7 @@
           diff (- after before)]
       (println (str diff " ms"))
       (println (str (:body resp)))
-      (is (< diff 10000)
+      (is (< diff 2000)
           "/stats/teams takes too long")
       (u/wipe-db system)
       (component/stop system))))

--- a/test/org/zalando/stups/pierone/perf_test.clj
+++ b/test/org/zalando/stups/pierone/perf_test.clj
@@ -1,0 +1,45 @@
+(ns org.zalando.stups.pierone.perf-test
+  (:require [org.zalando.stups.pierone.test-utils :as u]
+            [clojure.test :refer :all]
+            [clojure.data.json :as json]
+            [clojure.java.jdbc :as jdbc]
+            [clj-http.client :as http]
+            [digest :as hash]
+            [com.stuartsierra.component :as component]))
+
+
+(defn now [] (System/currentTimeMillis))
+
+(defn insert-huge-amount-of-data
+  [system]
+  (let [images (map #(assoc {} :i_id (hash/sha-256 (str "image" %))
+                               :i_metadata ""
+                               :i_accepted true
+                               :i_parent_id (hash/sha-256 (str "image" (inc %))))
+                    (range 1000))
+        tags (map #(assoc {} :t_team "stups"
+                             :t_artifact "kio"
+                             :t_name (str "tag" %)
+                             :t_image_id (hash/sha-256 (str "image" (+ % 900))))
+                  (range 50))]
+    (doseq [image images]
+      (println (str "Inserting image " (:i_id image)))
+      (jdbc/insert! (:db system) :images image))
+    (doseq [tag tags]
+      (println (str "Inserting tag " (:t_name tag)))
+      (jdbc/insert! (:db system) :tags tag))))
+
+(deftest perf-test
+  (let [system (u/setup)]
+    (u/wipe-db system)
+    (insert-huge-amount-of-data system)
+    (let [before (now)
+          resp (http/get (u/p1-url "/stats/teams"))
+          after (now)
+          diff (- after before)]
+      (println (str diff " ms"))
+      (println (str (:body resp)))
+      (is (< diff 10000)
+          "/stats/teams takes too long")
+      (u/wipe-db system)
+      (component/stop system))))

--- a/test/org/zalando/stups/pierone/pierone_test.clj
+++ b/test/org/zalando/stups/pierone/pierone_test.clj
@@ -7,11 +7,11 @@
             [com.stuartsierra.component :as component]))
 
 (deftest pierone-test
-  (let [system (u/setup d/all-tags
-                        d/all-images)
+  (let [system (u/setup)
         root (first d/images-hierarchy)
         alt (second d/images-hierarchy)]
 
+    (u/delete-test-data system)
     (u/push-images d/images-hierarchy)
 
     ; tag root image as regular tag

--- a/test/org/zalando/stups/pierone/v1_test.clj
+++ b/test/org/zalando/stups/pierone/v1_test.clj
@@ -8,9 +8,10 @@
             [com.stuartsierra.component :as component]))
 
 (deftest v1-test
-  (let [system (u/setup d/all-tags
-                        d/all-images)]
+  (let [system (u/setup)]
 
+    (u/delete-test-data system)
+    
     ; ping
     (u/expect 200 (client/get (u/v1-url "/_ping")
                               (u/http-opts)))

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -6,8 +6,7 @@
             [com.stuartsierra.component :as component]))
 
 (deftest v2-test
-  (let [system (u/setup d/all-tags
-                        d/all-images)]
+  (let [system (u/setup)]
 
     ; v2 compatibility check
     (let [result (client/get (u/v2-url "/")


### PR DESCRIPTION
Turns out the query itself is quite okay, taking around 20ms for an ancestry chain of 100 items and 1500 ms for 50K items. Chewing collections of several ten-thousands through threading macros was not the best idea.

Of course one could optimize further by saving sub-chains, e.g. by calculating the chain from img1 -> img2 -> .. -> img24 -> .. -> img25 we implicitly also know the chains for img2..img24. This would erase the need to fetch ancestries for common images like `node` or `jdk8` over and over again.
