### PR TITLE
Deprecate manifest v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-30
+FROM registry.opensource.zalan.do/stups/openjdk:8-37
 
 MAINTAINER Zalando SE
 

--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -242,7 +242,6 @@
   [manifest]
   (let [schema-version (:schemaVersion manifest)]
     (condp = schema-version
-      1 (map :blobSum (:fsLayers manifest))
       2 (apply conj
                [(get-in manifest [:config :digest])]
                (map :digest (:layers manifest)))
@@ -322,8 +321,8 @@
           schema-version (get parsed-manifest "schemaVersion")
           pretty (json/encode parsed-manifest {:pretty (get-json-pretty-printer)})
           set-header-fn #(condp = schema-version
-                          1 (ring/content-type % "application/vnd.docker.distribution.manifest.v1+prettyjws")
                           2 (ring/content-type % "application/vnd.docker.distribution.manifest.v2+json")
+                          (api/throw-error 400 (str "manifest schema version not supported: " schema-version))
                           %)]
       (-> (resp pretty request)
           (set-header-fn)

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -117,16 +117,16 @@
               (client/put (u/v2-url "/myteam/myart/manifests/1.0")
                           (u/http-opts (io/input-stream (:bytes d/manifest-v4)))))
 
-      (expect 201
+      (expect 400
+              ; manifest v1 format no longer supported
               (client/put (u/v2-url "/myteam/myart/manifests/1.0")
                           (u/http-opts (io/input-stream (:bytes d/manifest-v1)))))
 
-      (expect 409
-              ; duplicate tag
+      (expect 201
               (client/put (u/v2-url "/myteam/myart/manifests/1.0")
                           (u/http-opts (io/input-stream (:bytes d/manifest-v2)))))
 
-      (is (= (:pretty d/manifest-v1)
+      (is (= (:pretty d/manifest-v2)
              (expect 200
                      (client/get (u/v2-url "/myteam/myart/manifests/1.0")
                                  (u/http-opts)))))
@@ -153,37 +153,17 @@
       ; check that *-SNAPSHOT tags are mutable
       (expect 201
               (client/put (u/v2-url "/myteam/myart/manifests/1.0-SNAPSHOT")
-                          (u/http-opts (io/input-stream (:bytes d/manifest-v1)))))
+                          (u/http-opts (io/input-stream (:bytes d/manifest-v2)))))
 
       ; works, no changes
       (expect 201
               (client/put (u/v2-url "/myteam/myart/manifests/1.0-SNAPSHOT")
-                          (u/http-opts (io/input-stream (:bytes d/manifest-v1)))))
+                          (u/http-opts (io/input-stream (:bytes d/manifest-v2)))))
 
       (let [response (client/get (u/v2-url "/myteam/myart/manifests/1.0-SNAPSHOT")
                                  (u/http-opts))]
-        (is (= "application/vnd.docker.distribution.manifest.v1+prettyjws"
-               (get-in response [:headers "Content-Type"]))))
-
-      ; update, new manifest
-      (expect 201
-              (client/put (u/v2-url "/myteam/myart/manifests/1.0-SNAPSHOT")
-                          (u/http-opts (io/input-stream (:bytes d/manifest-v1-multilayer)))))
-
-      (is (= (:pretty d/manifest-v1-multilayer)
-             (expect 200
-                     (client/get (u/v2-url "/myteam/myart/manifests/1.0-SNAPSHOT")
-                                 (u/http-opts)))))
-
-      (expect 201 (client/put (u/v2-url "/myteam/myart/manifests/2.0-SNAPSHOT")
-                              (u/http-opts (io/input-stream (:bytes d/manifest-v2)))))
-
-      (let [response (client/get (u/v2-url "/myteam/myart/manifests/2.0-SNAPSHOT")
-                                 (u/http-opts))]
-
         (is (= "application/vnd.docker.distribution.manifest.v2+json"
                (get-in response [:headers "Content-Type"]))))
-
 
       ; stop
       (component/stop system))))


### PR DESCRIPTION
Fixes #105: remove support for v1 manifest format.
