### PR TITLE
Support pulling "latest" tag.

### DIFF
--- a/resources/db/v2.sql
+++ b/resources/db/v2.sql
@@ -45,6 +45,14 @@ SELECT t_manifest AS manifest
    AND t_artifact = :artifact
    AND t_name = :name;
 
+-- name: get-latest
+SELECT t_name AS name
+  FROM tags
+ WHERE t_team = :team
+   AND t_artifact = :artifact
+ ORDER BY t_created DESC
+ LIMIT 1;
+
 -- name: list-tag-names
 SELECT t_name AS name
   FROM tags

--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -331,10 +331,18 @@
               (log/warn "Prevented update of tag %s: %s" tag-ident (str e))
               (resp (get-error-response :TAG_INVALID {"Tag" name}) request :status 409))))))))
 
+(defn load-manifest
+  "Loads manifest from the DB, resolves `latest` tag automatically"
+  [{:keys [team artifact name]} db]
+  (when-let [real-name (if (= "latest" name)
+                         (:name (first (sql/get-latest {:team team :artifact artifact} {:connection db})))
+                         name)]
+    (:manifest (first (sql/get-manifest {:team team :artifact artifact :name real-name} {:connection db})))))
+
 (defn get-manifest
   "get"
   [parameters request db _ _ _]
-  (if-let [manifest (:manifest (first (sql/get-manifest parameters {:connection db})))]
+  (if-let [manifest (load-manifest parameters db)]
     (let [parsed-manifest (json/decode manifest)
           schema-version (get parsed-manifest "schemaVersion")
           pretty (json/encode parsed-manifest {:pretty (get-json-pretty-printer)})

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -134,6 +134,11 @@
                      (client/get (u/v2-url "/myteam/myart/manifests/1.0")
                                  (u/http-opts)))))
 
+      (is (= (:pretty d/manifest-v1)
+             (expect 200
+                     (client/get (u/v2-url "/myteam/myart/manifests/latest")
+                                 (u/http-opts)))))
+
       (is (= "{\"name\":\"myteam/myart\",\"tags\":[\"1.0\"]}"
              (expect 200
                      (client/get (u/v2-url "/myteam/myart/tags/list")


### PR DESCRIPTION
To address #21.

The `latest` tag will be resolved to the most recently created tag under the provided team and artifact. It will not show up in the list of all tags.