### PR TITLE
Support pulling by sha256

### DIFF
--- a/resources/db/migration/V6__Add_tag_content_digest.sql
+++ b/resources/db/migration/V6__Add_tag_content_digest.sql
@@ -1,0 +1,4 @@
+ALTER TABLE zp_data.tags
+  ADD COLUMN t_content_digest TEXT NULL;
+
+CREATE INDEX tags_content_digest_idx ON zp_data.tags(t_content_digest);

--- a/resources/db/v2.sql
+++ b/resources/db/v2.sql
@@ -20,13 +20,14 @@ UPDATE images
 
 -- name: create-manifest!
 INSERT INTO tags
-       (t_team, t_artifact, t_name, t_manifest, t_image_id, t_fs_layers, t_created_by, t_clair_id)
-VALUES (:team, :artifact, :name, :manifest, :image, ARRAY[ :fs_layers ], :user, :clair_id);
+       (t_team, t_artifact, t_name, t_manifest, t_image_id, t_fs_layers, t_created_by, t_clair_id, t_content_digest)
+VALUES (:team, :artifact, :name, :manifest, :image, ARRAY[ :fs_layers ], :user, :clair_id, :content_digest);
 
 -- name: update-manifest!
 UPDATE tags
    SET t_image_id = :image,
        t_manifest = :manifest,
+       t_content_digest = :content_digest,
        t_fs_layers = ARRAY[ :fs_layers ],
        -- updating is like overwriting (delete+create)
        -- i.e. update created timestamp and user
@@ -43,7 +44,7 @@ SELECT t_manifest AS manifest
   FROM tags
  WHERE t_team = :team
    AND t_artifact = :artifact
-   AND t_name = :name;
+   AND (t_name = :name OR t_content_digest = :name);
 
 -- name: list-tag-names
 SELECT t_name AS name

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -134,6 +134,11 @@
                      (client/get (u/v2-url "/myteam/myart/manifests/1.0")
                                  (u/http-opts)))))
 
+      (is (= (:pretty d/manifest-v1)
+             (expect 200
+                     (client/get (u/v2-url "/myteam/myart/manifests/sha256:b0ebea73273b4d5a334d74cd826a2327f260fe5212613937add8b5e171bf49bd")
+                                 (u/http-opts)))))
+
       (is (= "{\"name\":\"myteam/myart\",\"tags\":[\"1.0\"]}"
              (expect 200
                      (client/get (u/v2-url "/myteam/myart/tags/list")


### PR DESCRIPTION
To address #125. Only new images will be pullable by sha256:

    docker pull pierone.example.com/foo/bar@sha256:a18ed77532f6d6781500db650194e0f9396ba5f05f8b50d4046b294ae5f83aa4

To enable support of existing images we need to backfill the `tags.t_content_digest` column.