### PR TITLE
Support pulling by sha256

### DIFF
--- a/resources/db/migration/V6__Add_tag_content_digest.sql
+++ b/resources/db/migration/V6__Add_tag_content_digest.sql
@@ -1,0 +1,4 @@
+ALTER TABLE zp_data.tags
+  ADD COLUMN t_content_digest TEXT NULL;
+
+CREATE INDEX tags_content_digest_idx ON zp_data.tags(t_content_digest);

--- a/resources/db/v2.sql
+++ b/resources/db/v2.sql
@@ -20,13 +20,14 @@ UPDATE images
 
 -- name: create-manifest!
 INSERT INTO tags
-       (t_team, t_artifact, t_name, t_manifest, t_image_id, t_fs_layers, t_created_by, t_clair_id)
-VALUES (:team, :artifact, :name, :manifest, :image, ARRAY[ :fs_layers ], :user, :clair_id);
+       (t_team, t_artifact, t_name, t_manifest, t_image_id, t_fs_layers, t_created_by, t_clair_id, t_content_digest)
+VALUES (:team, :artifact, :name, :manifest, :image, ARRAY[ :fs_layers ], :user, :clair_id, :content_digest);
 
 -- name: update-manifest!
 UPDATE tags
    SET t_image_id = :image,
        t_manifest = :manifest,
+       t_content_digest = :content_digest,
        t_fs_layers = ARRAY[ :fs_layers ],
        -- updating is like overwriting (delete+create)
        -- i.e. update created timestamp and user
@@ -43,7 +44,7 @@ SELECT t_manifest AS manifest
   FROM tags
  WHERE t_team = :team
    AND t_artifact = :artifact
-   AND t_name = :name;
+   AND (t_name = :name OR t_content_digest = :name);
 
 -- name: get-latest
 SELECT t_name AS name

--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -250,6 +250,9 @@
       ; else
       (api/throw-error 400 (str "manifest schema version not compatible with this API: " schema-version)))))
 
+(defn prefixed-digest [text]
+  (str "sha256:" (digest/sha-256 text)))
+
 (defn put-manifest
   "Stores an image's JSON metadata. Last call in upload sequence."
   [{:keys [team artifact name data]} request db _ api-config {:keys [log-fn]}]
@@ -265,14 +268,17 @@
         registry (:callback-url api-config)
         clair-sqs-messages (map (partial clair/create-sqs-message registry team artifact) clair-hashes)
         digest (first fs-layers)
-        params-with-user {:team      team
-                          :artifact  artifact
-                          :name      name
-                          :image     digest
-                          :manifest  (json/generate-string manifest {:pretty true})
-                          :fs_layers fs-layers
-                          :user      uid
-                          :clair_id  topmost-layer-clair-id}
+        pretty-manifest-str (json/encode data {:pretty (get-json-pretty-printer)})
+        content-digest (prefixed-digest pretty-manifest-str)
+        params-with-user {:team           team
+                          :artifact       artifact
+                          :name           name
+                          :image          digest
+                          :manifest       (json/generate-string manifest {:pretty true})
+                          :fs_layers      fs-layers
+                          :user           uid
+                          :clair_id       topmost-layer-clair-id
+                          :content_digest content-digest}
         tag-ident (str team "/" artifact ":" name)]
     (when-not (seq fs-layers)
       (api/throw-error 400 "manifest has no FS layers"))
@@ -310,11 +316,7 @@
                :tag name
                :repository (:repository api-config)})))
         (-> (resp "OK" request :status 201)
-            (ring/header "Docker-Content-Digest"
-                         (str "sha256:"
-                              (-> data
-                                  (json/encode {:pretty (get-json-pretty-printer)})
-                                  (digest/sha-256)))))
+            (ring/header "Docker-Content-Digest" content-digest))
 
         ; TODO check for hystrix exception and replace sql above with cmd- version
         (catch SQLException e
@@ -345,15 +347,15 @@
   (if-let [manifest (load-manifest parameters db)]
     (let [parsed-manifest (json/decode manifest)
           schema-version (get parsed-manifest "schemaVersion")
-          pretty (json/encode parsed-manifest {:pretty (get-json-pretty-printer)})
+          pretty-manifest-str (json/encode parsed-manifest {:pretty (get-json-pretty-printer)})
           set-header-fn #(condp = schema-version
                           1 (ring/content-type % "application/vnd.docker.distribution.manifest.v1+prettyjws")
                           2 (ring/content-type % "application/vnd.docker.distribution.manifest.v2+json")
                           (api/throw-error 400 (str "manifest schema version not supported: " schema-version))
                           %)]
-      (-> (resp pretty request)
+      (-> (resp pretty-manifest-str request)
           (set-header-fn)
-          (ring/header "Docker-Content-Digest" (str "sha256:" (digest/sha-256 pretty)))))
+          (ring/header "Docker-Content-Digest" (prefixed-digest pretty-manifest-str))))
     (resp (get-error-response :MANIFEST_UNKNOWN {"Parameters" parameters}) request :status 404)))
 
 (defn list-tags

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -136,6 +136,11 @@
 
       (is (= (:pretty d/manifest-v1)
              (expect 200
+                     (client/get (u/v2-url "/myteam/myart/manifests/sha256:b0ebea73273b4d5a334d74cd826a2327f260fe5212613937add8b5e171bf49bd")
+                                 (u/http-opts)))))
+
+      (is (= (:pretty d/manifest-v1)
+             (expect 200
                      (client/get (u/v2-url "/myteam/myart/manifests/latest")
                                  (u/http-opts)))))
 


### PR DESCRIPTION
To address #125. Only new images will be pullable by sha256:

    docker pull pierone.example.com/foo/bar@sha256:a18ed77532f6d6781500db650194e0f9396ba5f05f8b50d4046b294ae5f83aa4

To enable support of existing images we need to backfill the `tags.t_content_digest` column.