### PR TITLE
Resubmitting to Clair-SQS

### DIFF
--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -796,6 +796,32 @@ paths:
         "404":
           description: Image not found
 
+  /teams/{team}/artifacts/{artifact}/recheck:
+    post:
+      summary: Rescan all images of an artifact
+      description: Submit all images of a single artifact to Clair for security rescan
+      tags:
+        - Pier One API
+      operationId: org.zalando.stups.pierone.api/post-recheck-artifact-images!
+      security:
+        - oauth2: [uid]
+      parameters:
+        - name: team
+          in: path
+          required: true
+          type: string
+        - name: artifact
+          in: path
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Clair integration is not configured, nothing is done
+        "202":
+          description: Successfully resubmitted the images
+        "404":
+          description: No images found
+
   /tags/{image}:
     get:
       summary: List tags for image

--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -766,6 +766,36 @@ paths:
           schema:
             $ref: "#/definitions/ScmSourceInformation"
 
+  /teams/{team}/artifacts/{artifact}/tags/{tag}/recheck:
+    post:
+      summary: Rescan image
+      description: Submit the image to Clair for security rescan
+      tags:
+        - Pier One API
+      operationId: org.zalando.stups.pierone.api/post-recheck!
+      security:
+        - oauth2: [uid]
+      parameters:
+        - name: team
+          in: path
+          required: true
+          type: string
+        - name: artifact
+          in: path
+          required: true
+          type: string
+        - name: tag
+          in: path
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Clair integration is not configured, nothing is done
+        "202":
+          description: Successfully resubmitted the image
+        "404":
+          description: Image not found
+
   /tags/{image}:
     get:
       summary: List tags for image

--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -772,7 +772,7 @@ paths:
       description: Submit the image to Clair for security rescan
       tags:
         - Pier One API
-      operationId: org.zalando.stups.pierone.api/post-recheck!
+      operationId: org.zalando.stups.pierone.api/post-recheck-image!
       security:
         - oauth2: [uid]
       parameters:

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -129,7 +129,7 @@
         (ring/response)
         (fring/content-type-json))))
 
-(defn post-recheck!
+(defn post-recheck-image!
   "Resubmit an image to Clair for security checking."
   [{:as params :keys [team artifact]} _ db _ api-config _]
   (prn params)

--- a/src/org/zalando/stups/pierone/api.clj
+++ b/src/org/zalando/stups/pierone/api.clj
@@ -129,27 +129,53 @@
         (ring/response)
         (fring/content-type-json))))
 
+(defn send-clair-notification [team artifact tag db api-config]
+  (if-let [manifest-str (org.zalando.stups.pierone.api-v2/load-manifest {:team team :artifact artifact :name tag} db)]
+    (let [manifest (json/decode manifest-str keyword)
+          clair-hashes (clair/prepare-hashes-for-clair manifest)
+          topmost-layer-clair-id (-> clair-hashes last :current :clair-id)
+          queue-url (:clair-layer-push-queue-url api-config)
+          queue-region (:clair-layer-push-queue-region api-config)
+          registry (:callback-url api-config)
+          clair-sqs-messages (map (partial clair/create-sqs-message registry team artifact) clair-hashes)]
+      (log/info "Resubmitting image to Clair: %s" topmost-layer-clair-id)
+      (clair/send-sqs-message queue-region queue-url clair-sqs-messages)
+      (-> {:message "Image resubmitted"
+           :clair-sqs-messages clair-sqs-messages}
+          (ring/response)
+          (ring/status 202)
+          (fring/content-type-json)))
+    (ring/not-found nil)))
+
 (defn post-recheck-image!
   "Resubmit an image to Clair for security checking."
-  [{:as params :keys [team artifact]} _ db _ api-config _]
-  (prn params)
+  [{:keys [team artifact tag]} _ db _ api-config _]
   (let [queue-url (:clair-layer-push-queue-url api-config)
         queue-region (:clair-layer-push-queue-region api-config)]
     (if (some str/blank? [queue-region queue-url])
       (-> {:message "Clair integration not configured, not doing anything"}
           (ring/response)
           (fring/content-type-json))
-      (if-let [manifest-str (org.zalando.stups.pierone.api-v2/load-manifest (assoc params :name (:tag params)) db)]
-        (let [manifest (json/decode manifest-str keyword)
-              clair-hashes (clair/prepare-hashes-for-clair manifest)
-              topmost-layer-clair-id (-> clair-hashes last :current :clair-id)
-              registry (:callback-url api-config)
-              clair-sqs-messages (map (partial clair/create-sqs-message registry team artifact) clair-hashes)]
-          (log/info "Resubmitting image to Clair: %s" topmost-layer-clair-id)
-          (clair/send-sqs-message queue-region queue-url clair-sqs-messages)
-          (-> {:message "Image resubmitted"
-               :clair-sqs-messages clair-sqs-messages}
-              (ring/response)
-              (ring/status 202)
-              (fring/content-type-json)))
-        (ring/not-found nil)))))
+      (send-clair-notification team artifact tag db api-config))))
+
+
+(defn post-recheck-artifact-images!
+  "Submit all images of a single artifact to Clair for security rescan."
+  [{:keys [team artifact]} _ db _ api-config _]
+  (let [queue-url (:clair-layer-push-queue-url api-config)
+        queue-region (:clair-layer-push-queue-region api-config)]
+    (if (some str/blank? [queue-region queue-url])
+      (-> {:message "Clair integration not configured, not doing anything"}
+          (ring/response)
+          (fring/content-type-json))
+      (let [tags (sql/cmd-list-tags {:team team :artifact artifact} {:connection db})]
+        (doseq [tag tags]
+          (send-clair-notification team artifact (:name tag) db api-config))
+        (-> {:tags    (for [tag tags]
+                        {:name     (:name tag)
+                         :clair-id (:clair_id tag)
+                         :id       (:image tag)})
+             :message "Images resubmitted"}
+            (ring/response)
+            (ring/status 202)
+            (fring/content-type-json))))))

--- a/test/org/zalando/stups/pierone/pierone_test.clj
+++ b/test/org/zalando/stups/pierone/pierone_test.clj
@@ -145,6 +145,15 @@
                 :message            "Image resubmitted"}
                (:body resp))))
 
+      (let [resp (client/post (u/p1-url "/teams/myteam/artifacts/myart/recheck")
+                              (merge (u/http-opts)
+                                     {:as :json}))]
+        (is (= 202 (:status resp)))
+        (is (= {:message "Images resubmitted"
+                :tags    [{:name     "1.0"
+                           :id       "sha256:a5c741c7dea3a96944022b4b9a0b1480cfbeef5f4cc934850e8afacb48e18c5e"
+                           :clair-id "sha256:e5d6433ddaf1c332d356a026a065c874bc0ef2553650a8134356320679076d7b"}]}
+               (:body resp))))
 
       ; stop
       (component/stop system))))

--- a/test/org/zalando/stups/pierone/test_data.clj
+++ b/test/org/zalando/stups/pierone/test_data.clj
@@ -57,4 +57,4 @@
       :artifact "kio"
       :name     "1.0-SNAPSHOT"})
 
-(def all-tags (conj [] tag snapshot-tag))
+(def all-tags [tag snapshot-tag])

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -56,12 +56,13 @@
       (provided
         (auth/require-write-access "team" request) => nil))))
 
-
-(defn expect [status-code response]
-  (is (= (:status response)
-        status-code)
-    (apply str "response of wrong status: " response))
-  (:body response))
+(defmacro expect [status-code expression]
+  `(let [status-code# ~status-code
+         response# ~expression]
+    (is (= (:status response#)
+           status-code#)
+        (apply str "response of wrong status: " response#))
+    (:body response#)))
 
 (deftest ^:integration v2-integration-test
   (with-redefs [org.zalando.stups.pierone.clair/send-sqs-message (fn [& _])


### PR DESCRIPTION
In order to trigger rescanning of images, here are 2 new endpoints:

```
$ http POST https://pierone.example.org/teams/TEAM_NAME/artifacts/ARTIFACT_NAME/recheck
$ http POST https://pierone.example.org/teams/TEAM_NAME/artifacts/ARTIFACT_NAME/tags/TAG_NAME/recheck
```

When an image is pushed, this is triggered automatically, however, sometimes [Clair-SQS](https://github.com/zalando-incubator/clair-sqs) fails to notify PierOne of security updates of old images.

In such cases these endpoints will be useful.