### PR TITLE
#130 Quick hack for compatibility with Docker 1.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-cd27
+FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 MAINTAINER Zalando SE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-42
+FROM registry.opensource.zalan.do/stups/openjdk:8-cd27
 
 MAINTAINER Zalando SE
 

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,26 @@ Run the development web server with:
 
 The web server will run on port 8080. You can find the Swagger UI on http://localhost:8080/ui/.
 
+Testing with different client versions
+--------------------------------------
+
+Use docker in docker: https://hub.docker.com/r/library/docker/
+
+For example:
+
+```sh
+# First push the image
+$ docker push my-machine-hostname:8080/foo/bar:123
+# Try to pull it using a specific version of docker (1.11)
+# Start the daemon
+$ docker run -it --privileged --name docker11 -d docker:1.11-dind --insecure-registry my-machine-hostname:8080
+# Execute the command
+$ docker run -it --rm --link docker11:docker docker:1.11 docker pull my-machine-hostname:8080/foo/bar:123
+# ... execute more commands
+# Stop the daemon
+$ docker rm -fv docker11
+```
+
 Testing
 =======
 

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -193,10 +193,12 @@
                               (u/http-opts (io/input-stream (:bytes d/manifest-v2)))))
 
       (let [response (client/get (u/v2-url "/myteam/myart/manifests/2.0-SNAPSHOT")
-                                 (u/http-opts))]
+                                 (merge (u/http-opts) {:as :json}))]
 
         (is (= "application/vnd.docker.distribution.manifest.v2+json"
-               (get-in response [:headers "Content-Type"]))))
+               (get-in response [:headers "Content-Type"])))
+        (is (= "application/vnd.docker.container.image.v1+json"
+               (get-in response [:body :config :mediaType]))))
 
 
       ; stop


### PR DESCRIPTION
If config.mediaType is equal to "application/json" in the manifest, set it to "application/vnd.docker.container.image.v1+json".
Addresses #130.