### PR TITLE
Support overriding of scm-source.json via X-SCM-Source header, but on…

### DIFF
--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -250,6 +250,10 @@ paths:
         - $ref: '#/parameters/team'
         - $ref: '#/parameters/artifact'
         - $ref: '#/parameters/name'
+        - name: x-scm-source
+          in: header
+          type: string
+          required: false
         - name: data
           in: body
           schema:

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -74,6 +74,21 @@ SELECT ssd_url AS url,
 ORDER BY created DESC
  LIMIT 1;
 
+-- name: create-or-update-scm-source-data!
+WITH scm_source_data_update AS (
+     UPDATE scm_source_data
+        SET ssd_url = :url,
+            ssd_revision = :revision,
+            ssd_author = :author,
+            ssd_status = :status
+      WHERE ssd_image_id = :image
+  RETURNING ssd_image_id
+)
+INSERT INTO scm_source_data
+       (ssd_image_id, ssd_url, ssd_revision, ssd_author, ssd_status)
+     SELECT :image, :url, :revision, :author, :status
+      WHERE NOT EXISTS (SELECT 1 FROM scm_source_data_update);
+
 -- name: get-total-storage
 SELECT SUM(i_size) AS total
   FROM images

--- a/src/org/zalando/stups/pierone/api_v1.clj
+++ b/src/org/zalando/stups/pierone/api_v1.clj
@@ -129,13 +129,13 @@
     (if (= "latest" tag-name)
       (resp "tag latest is not allowed" request :status 409)
       (try
-        (sql/create-tag! params-with-user connection)
+        (sql/cmd-create-tag! params-with-user connection)
         (log/info "Stored new tag %s." params-with-user)
         (let [tag-info {:team team
                         :artifact artifact
                         :tag name
                         :repository (:repository api-config)}
-              scm-source (first (sql/get-scm-source
+              scm-source (first (sql/cmd-get-scm-source
                                   tag-info
                                   {:connection db}))]
           (log-fn (audit/tag-uploaded (:tokeninfo request) scm-source tag-info)))
@@ -171,8 +171,8 @@
   "Stores an image's JSON metadata. First call in upload sequence."
   [{:keys [image metadata]} request db _ _ _]
   (try
-    (sql/delete-unaccepted-image! {:image image} {:connection db})
-    (sql/create-image!
+    (sql/cmd-delete-unaccepted-image! {:image image} {:connection db})
+    (sql/cmd-create-image!
       {:image    image
        :metadata (json/generate-string metadata)
        :parent   (get metadata "parent")

--- a/src/org/zalando/stups/pierone/api_v1.clj
+++ b/src/org/zalando/stups/pierone/api_v1.clj
@@ -129,7 +129,7 @@
     (if (= "latest" tag-name)
       (resp "tag latest is not allowed" request :status 409)
       (try
-        (sql/cmd-create-tag! params-with-user connection)
+        (sql/create-tag! params-with-user connection)
         (log/info "Stored new tag %s." params-with-user)
         (let [tag-info {:team team
                         :artifact artifact
@@ -171,8 +171,8 @@
   "Stores an image's JSON metadata. First call in upload sequence."
   [{:keys [image metadata]} request db _ _ _]
   (try
-    (sql/cmd-delete-unaccepted-image! {:image image} {:connection db})
-    (sql/cmd-create-image!
+    (sql/delete-unaccepted-image! {:image image} {:connection db})
+    (sql/create-image!
       {:image    image
        :metadata (json/generate-string metadata)
        :parent   (get metadata "parent")

--- a/src/org/zalando/stups/pierone/auth.clj
+++ b/src/org/zalando/stups/pierone/auth.clj
@@ -24,10 +24,16 @@
   ; either user has write access to all (service user)
   ; or user belongs to a team (employee user)
   (when (get-in request [:configuration :tokeninfo-url])
-    (when-not (some #{"application.write_all"} (get tokeninfo "scope"))
+    (when-not (some #{"application.write_all" "application.write_all_trusted"} (get tokeninfo "scope"))
       (user/require-realms #{"services" "employees"} request)
       (case (get tokeninfo "realm")
         "/services" (do
                       (require-scope request "application.write")
                       (cached-require-auth request team))
         "/employees" (cached-require-auth request team)))))
+
+(defn require-trusted-write-access
+  "Require trusted write access to any repository"
+  [request]
+  (when (get-in request [:configuration :tokeninfo-url])
+    (require-scope request "application.write_all_trusted")))

--- a/src/org/zalando/stups/pierone/clair.clj
+++ b/src/org/zalando/stups/pierone/clair.clj
@@ -113,7 +113,7 @@
        :severity-no-fix-available (or (find-highest-severity noFixAvailable) "clair:NoCVEsFound")})))
 
 (defn store-clair-summary [db {:keys [clair-id severity-fix-available severity-no-fix-available]}]
-  (sql/update-tag-severity! {:clair_id                  clair-id
+  (sql/cmd-update-tag-severity! {:clair_id                  clair-id
                              :severity_fix_available    severity-fix-available
                              :severity_no_fix_available severity-no-fix-available} {:connection db}))
 

--- a/src/org/zalando/stups/pierone/http/protectors.clj
+++ b/src/org/zalando/stups/pierone/http/protectors.clj
@@ -12,10 +12,10 @@
   Timeouts are handled by surrounding Hystrix command."
   [url signature]
   (let [{:keys [status]} (http/post url
-                                         {:content-type     :json
-                                          :form-params      {:iid_signature signature}
-                                          :as               :json
-                                          :throw-exceptions false})]
+                                    {:content-type     :json
+                                     :form-params      {:iid_signature signature}
+                                     :as               :json
+                                     :throw-exceptions false})]
     (= 200 status)))
 
 (hystrix/defcommand is-valid-iid?

--- a/test/org/zalando/stups/pierone/test_utils.clj
+++ b/test/org/zalando/stups/pierone/test_utils.clj
@@ -63,8 +63,9 @@
 (defn wipe-db
   [system]
   (println "Deleting all tags and images")
-  (jdbc/delete! (:db system) :tags ["t_name IS NOT NULL"])
-  (jdbc/delete! (:db system) :images ["i_id IS NOT NULL"])
+  (jdbc/delete! (:db system) :scm_source_data ["true"])
+  (jdbc/delete! (:db system) :tags ["true"])
+  (jdbc/delete! (:db system) :images ["true"])
   system)
 
 ; setup

--- a/test/org/zalando/stups/pierone/util_test.clj
+++ b/test/org/zalando/stups/pierone/util_test.clj
@@ -30,6 +30,6 @@
     (fact "calls require-auth"
       (auth/require-write-access "team" request) => (throws Exception)
       (provided
-        (auth/cached-require-auth request "team") => (throws Exception))))
+        (auth/cached-require-auth request "team") =throws=> (Exception.))))
 
   )

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -33,8 +33,8 @@
         (v2/get-fs-layers "manifest") => ["digest"]
         (clair/prepare-hashes-for-clair "manifest") => []
         (jdbc/db-transaction* nil anything) => nil
-        (sql/get-scm-source {:team "team" :artifact "artifact" :tag "name"} {:connection nil}) => {}
-        (sql/image-blob-exists {:image "digest"} {:connection nil}) => [0 1 2]
+        (sql/cmd-get-scm-source {:team "team" :artifact "artifact" :tag "name"} {:connection nil}) => {}
+        (sql/cmd-image-blob-exists {:image "digest"} {:connection nil}) => [0 1 2]
         (auth/require-write-access "team" request) => nil))
     (fact "patch-upload"
       (let [file (new File "foo")]
@@ -49,7 +49,7 @@
     (fact "put-upload"
       (v2/put-upload params request nil nil nil nil) => truthy
       (provided
-        (sql/accept-image-blob! {:image "digest"} {:connection nil}) => 0
+        (sql/cmd-accept-image-blob! {:image "digest"} {:connection nil}) => 0
         (auth/require-write-access "team" request) => nil))
     (fact "post-upload"
       (v2/post-upload params request nil nil nil nil) => truthy


### PR DESCRIPTION
…ly when application.write_all_trusted scope is set.

This is used by CI to avoid requiring the users to include `/scm-source.json` file (and to avoid relying on it).