### PR TITLE
URL-decode X-SCM-Source header contents.

### DIFF
--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -17,7 +17,8 @@
             [com.netflix.hystrix.core :refer [defcommand]]
             [org.zalando.stups.pierone.storage :as s]
             [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [ring.util.codec :as ruc])
   (:import (java.sql SQLException)
            (java.util UUID)
            (java.io File)
@@ -213,7 +214,7 @@
 
 (defn update-scm-source [db image-id x-scm-source]
   (when x-scm-source
-    (let [{:keys [author url revision status]} (json/parse-string x-scm-source keyword)
+    (let [{:keys [author url revision status]} (json/parse-string (ruc/url-decode x-scm-source) keyword)
           scm-source-data-params {:image    image-id
                                   :author   author
                                   :url      url

--- a/src/org/zalando/stups/pierone/http/protectors.clj
+++ b/src/org/zalando/stups/pierone/http/protectors.clj
@@ -65,7 +65,7 @@
       :else
       (try
         (let [[username password] (-> req auth-header parse-auth-header)]
-          (log/info "Checking IID %s %s" username password)
+          ;(log/info "Checking IID %s %s" username password)
           (if (is-valid-iid? iidinfo-url password)
             req
             (do


### PR DESCRIPTION
It's necessary in case the proxy encodes this header.
Also don't leak IIDs into logs.