### PR TITLE
Make GET /v2/ return plain text OK, not json "OK"

### DIFF
--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -72,10 +72,14 @@
   [storage image]
   (s/read-data storage image))
 
+(defn ping-ok []
+  (-> (ring/response "OK")
+      (ring/header "Docker-Distribution-API-Version" "registry/2.0")))
+
 (defn ping
   "Checks for compatibility with version 2."
   [_ request _ _ _ _]
-  (resp "\"OK\"" request))
+  (ping-ok))
 
 (defn post-upload
   ""


### PR DESCRIPTION
json "OK" makes rkt fall back to v1, which is not fully supported