### PR TITLE
Restore GET /v2/ to support HTTP_ALLOW_PUBLIC_READ.

### DIFF
--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -135,9 +135,13 @@ paths:
       tags:
         - Docker Registry API v2
       operationId: org.zalando.stups.pierone.api-v2/ping
-      security:
-        - oauth2: [uid]
-        - iid:
+      # GET /v2/ must be protected, this is how docker CLI determines whether to inject Authorization header
+      #  in subsequent calls
+      # However, it is handled inside org.zalando.stups.pierone.api-v2/ping because for public read mode
+      #  we need to decide based on the hostname (registry.opensource.zalan.do or registry-write.opensource.zalan.do)
+#      security:
+#        - oauth2: [uid]
+#        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
       responses:
         "200":
           description: v2 is available
@@ -855,7 +859,7 @@ paths:
       operationId: org.zalando.stups.pierone.api/list-tags-for-image
       security:
         - oauth2: [uid]
-        - iid:
+        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
       parameters:
         - name: image
           in: path
@@ -881,7 +885,7 @@ paths:
       operationId: org.zalando.stups.pierone.api/get-overall-stats
       security:
         - oauth2: [uid]
-        - iid:
+        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
       responses:
         "200":
           description: Return stats
@@ -897,7 +901,7 @@ paths:
       operationId: org.zalando.stups.pierone.api/get-teams-stats
       security:
         - oauth2: [uid]
-        - iid:
+        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
       responses:
         "200":
           description: Return team stats
@@ -913,7 +917,7 @@ paths:
       operationId: org.zalando.stups.pierone.api/get-team-stats
       security:
         - oauth2: [uid]
-        - iid:
+        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
       parameters:
         - name: team
           in: path

--- a/src/org/zalando/stups/pierone/api_v2.clj
+++ b/src/org/zalando/stups/pierone/api_v2.clj
@@ -72,14 +72,43 @@
   [storage image]
   (s/read-data storage image))
 
+(defn ping-unauthorized []
+  (-> (ring/response "Unauthorized")
+      (ring/status 401)
+      (ring/header "WWW-Authenticate" "Basic realm=\"Pier One Docker Registry\"")
+      ; IMPORTANT: we need to set the V2 header here (even for 401 status code!),
+      ; otherwise the Docker client will fallback to V1
+      (ring/header "Docker-Distribution-API-Version" "registry/2.0")))
+
 (defn ping-ok []
   (-> (ring/response "OK")
       (ring/header "Docker-Distribution-API-Version" "registry/2.0")))
 
+(defn is-write-domain
+  "Check whether the current 'Host' (domain) is to push images.
+  This is a workaround for the misbehaving Docker client (see https://github.com/zalando-stups/pierone/issues/57)."
+  [request]
+  (if-let [host (get-in request [:headers "host"])]
+    (.contains host "write")
+    (false)))
+
 (defn ping
   "Checks for compatibility with version 2."
   [_ request _ _ _ _]
-  (ping-ok))
+  ; NOTE: we are doing our own OAuth check here as Docker requires an extra V2 header set
+  (let [config (:configuration request)
+        tokeninfo-url (:tokeninfo-url config)
+        allow-public-read (:allow-public-read config)]
+    (if (and tokeninfo-url (or (not allow-public-read) (is-write-domain request)))
+      (if-let [access-token (#'io.sarnowski.swagger1st.util.security/extract-access-token request)]
+        ; check access token
+        (if-let [tokeninfo (resolve-access-token tokeninfo-url access-token)]
+          (ping-ok)
+          (ping-unauthorized))
+        ; missing access token
+        (ping-unauthorized))
+      ; no tokeninfo URL => no security checks
+      (ping-ok))))
 
 (defn post-upload
   ""


### PR DESCRIPTION
Also remove iid security requirement in HTTP_ALLOW_PUBLIC_READ to prevent exposing certain APIs.