### PR TITLE
Improve scm-source handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV HTTP_PORT 8080
 COPY run.sh /
 
 COPY target/pierone.jar /
-COPY target/scm-source.json /
 
 COPY resources/ /resources/
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -8,30 +8,26 @@ build_steps:
     curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein >/usr/bin/lein
     chmod a+x /usr/bin/lein
     # Docker
-    apt-get install -y apt-transport-https ca-certificates curl software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-    apt-key fingerprint 0EBFCD88
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    apt-get update
-    apt-get install -y docker-ce
+    curl -sSL https://delivery.cloud.zalando.com/utils/ensure-docker | sh
 - desc: Run unit tests
   cmd: |
     export LEIN_ROOT=1
     docker run -d -p 5432:5432 postgres:9.4
-    DB_SUBNAME=//localhost:5432/postgres lein test
+    lein test
 - desc: Build and push docker image
   cmd: |
     export LEIN_ROOT=1
     # TODO remove scm-source.json from Dockerfile first
     lein set-version "${CDP_BUILD_VERSION}"
     lein uberjar
-    touch target/scm-source.json
     if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
       IMAGE_NAME=pierone
     else
       IMAGE_NAME=pierone-test
     fi
-    docker build -t pierone.stups.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION} .
-    docker push pierone.stups.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION}
-    docker tag pierone.stups.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION} registry-write.opensource.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION}
-    docker push registry-write.opensource.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION}
+    PRIVATE_IMAGE=pierone.stups.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION}
+    OPENSOURCE_IMAGE=registry-write.opensource.zalan.do/stups/${IMAGE_NAME}:${CDP_BUILD_VERSION}
+    docker build -t "$PRIVATE_IMAGE" .
+    docker push "$PRIVATE_IMAGE"
+    docker tag "$PRIVATE_IMAGE" "$OPENSOURCE_IMAGE"
+    docker push "$OPENSOURCE_IMAGE"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -26,9 +26,7 @@ build_steps:
     lein set-version "${CDP_BUILD_VERSION}"
     lein uberjar
     touch target/scm-source.json
-    IS_PR_BUILD=${CDP_PULL_REQUEST_NUMBER+"true"}
-    if [[ $CDP_TARGET_BRANCH == "master" && ${IS_PR_BUILD} != "true" ]]
-    then
+    if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
       IMAGE_NAME=pierone
     else
       IMAGE_NAME=pierone-test

--- a/resources/db/migration/V7__Create_scm_source_data_by_tag.sql
+++ b/resources/db/migration/V7__Create_scm_source_data_by_tag.sql
@@ -1,0 +1,16 @@
+SET search_path TO zp_data;
+
+CREATE TABLE scm_source_data_by_tag (
+  ssdbt_team     TEXT NOT NULL,
+  ssdbt_artifact TEXT NOT NULL,
+  ssdbt_name     TEXT NOT NULL,
+
+  ssdbt_url      TEXT NOT NULL,
+  ssdbt_revision TEXT NOT NULL,
+  ssdbt_author   TEXT NOT NULL,
+  ssdbt_status   TEXT NOT NULL,
+  ssdbt_created timestamp NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (ssdbt_team, ssdbt_artifact, ssdbt_name),
+  FOREIGN KEY (ssdbt_team, ssdbt_artifact, ssdbt_name) REFERENCES tags (t_team, t_artifact, t_name)
+);

--- a/resources/db/pierone.sql
+++ b/resources/db/pierone.sql
@@ -52,6 +52,19 @@ WITH RECURSIVE parents(i_id)
                parents p
          WHERE img.i_id = p.i_id
            AND img.i_accepted = TRUE)
+-- latest approach: use separate table to store SCM-Source info that came in X-SCM-Source header
+-- it has higher precedence over layer-specific data
+SELECT ssdbt_url AS url,
+       ssdbt_revision AS revision,
+       ssdbt_author AS author,
+       ssdbt_status AS status,
+       ssdbt_created AS created
+  FROM scm_source_data_by_tag
+ WHERE ssdbt_team = :team
+   AND ssdbt_artifact = :artifact
+   AND ssdbt_name = :tag
+UNION
+-- v1: images pushed through /v1 API (DEPRECATED)
 SELECT ssd_url AS url,
        ssd_revision AS revision,
        ssd_author AS author,
@@ -72,22 +85,7 @@ SELECT ssd_url AS url,
    AND t_artifact = :artifact
    AND t_name = :tag
 ORDER BY created DESC
- LIMIT 1;
-
--- name: create-or-update-scm-source-data!
-WITH scm_source_data_update AS (
-     UPDATE scm_source_data
-        SET ssd_url = :url,
-            ssd_revision = :revision,
-            ssd_author = :author,
-            ssd_status = :status
-      WHERE ssd_image_id = :image
-  RETURNING ssd_image_id
-)
-INSERT INTO scm_source_data
-       (ssd_image_id, ssd_url, ssd_revision, ssd_author, ssd_status)
-     SELECT :image, :url, :revision, :author, :status
-      WHERE NOT EXISTS (SELECT 1 FROM scm_source_data_update);
+LIMIT 1;
 
 -- name: get-total-storage
 SELECT SUM(i_size) AS total
@@ -99,3 +97,8 @@ UPDATE tags
    SET t_severity_fix_available = :severity_fix_available,
        t_severity_no_fix_available = :severity_no_fix_available
  WHERE t_clair_id = :clair_id;
+
+-- name: insert-scm-source-data-by-tag!
+INSERT INTO scm_source_data_by_tag
+  (ssdbt_team, ssdbt_artifact, ssdbt_name, ssdbt_url, ssdbt_revision, ssdbt_author, ssdbt_status)
+VALUES(:team, :artifact, :name, :url, :revision, :author, :status);

--- a/src/org/zalando/stups/pierone/lib/nrepl.clj
+++ b/src/org/zalando/stups/pierone/lib/nrepl.clj
@@ -32,7 +32,8 @@
 (defonce nrepl-server nil)
 
 (defn run-nrepl []
-  (let [config (config/load-configuration [:nrepl] {})]
+  ;; :nrepl-bind defaults to "::", which might not be supported in some environments
+  (let [config (config/load-configuration [:nrepl] [{:nrepl-bind "0.0.0.0"}])]
     (when (-> config :nrepl :enabled)
       (let [nrepl (map->NREPL {:configuration (:nrepl config)})]
         (component/start nrepl)))))

--- a/test/org/zalando/stups/pierone/test_utils.clj
+++ b/test/org/zalando/stups/pierone/test_utils.clj
@@ -62,7 +62,8 @@
 
 (defn wipe-db
   [system]
-  (println "Deleting all tags and images")
+  (println "Wiping all tables")
+  (jdbc/delete! (:db system) :scm_source_data_by_tag ["true"])
   (jdbc/delete! (:db system) :scm_source_data ["true"])
   (jdbc/delete! (:db system) :tags ["true"])
   (jdbc/delete! (:db system) :images ["true"])

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -29,15 +29,15 @@
   (facts "calls require-write-access with correct params"
     (facts "about update-scm-source"
       (fact "Parses header contents and puts it into the DB"
-        (v2/update-scm-source ..db.. ..image.. (json/generate-string {:author "a" :url "u" :revision "r" :status "s"})) => nil
+        (v2/insert-scm-source-by-tag ..db.. ..t.. ..a.. ..n.. (json/generate-string {:author "a" :url "u" :revision "r" :status "s"})) => nil
         (provided
-          (sql/cmd-create-or-update-scm-source-data!
-            {:image ..image.. :author "a" :url "u" :revision "r" :status "s"} {:connection ..db..})
+          (sql/cmd-insert-scm-source-data-by-tag!
+            {:team ..t.. :artifact ..a.. :name ..n.. :author "a" :url "u" :revision "r" :status "s"} {:connection ..db..})
           => nil))
       (fact "When header content is invalid, throws, but logs a WARN"
-        (v2/update-scm-source ..db.. ..image.. "(foo") => (throws Exception)
+        (v2/insert-scm-source-by-tag ..db.. ..t.. ..a.. ..n.. "(foo") => (throws Exception)
         (provided
-          (sql/cmd-create-or-update-scm-source-data! anything anything) => nil :times 0)))
+          (sql/cmd-insert-scm-source-data-by-tag! anything anything anything anything anything) => nil :times 0)))
     (fact "put-manifest"
       (v2/put-manifest params request nil nil nil {:log-fn identity}) => truthy
       (provided


### PR DESCRIPTION
Store SCM-Source into received from X-SCM-Source header in a separate table.
When exposing SCM-Source info, use that table with higher priority.