### PR TITLE
Alter i_size column to BIGINT in images table

### DIFF
--- a/resources/db/migration/V2__Add_image_size.sql
+++ b/resources/db/migration/V2__Add_image_size.sql
@@ -1,4 +1,4 @@
 -- store image size on upload
--- to not touch files when someone requests stats
+-- do not touch files when someone requests stats
 ALTER TABLE zp_data.images
  ADD COLUMN i_size INTEGER;

--- a/resources/db/migration/V2__Add_image_size.sql
+++ b/resources/db/migration/V2__Add_image_size.sql
@@ -1,4 +1,4 @@
 -- store image size on upload
--- do not touch files when someone requests stats
+-- to not touch files when someone requests stats
 ALTER TABLE zp_data.images
  ADD COLUMN i_size INTEGER;

--- a/resources/db/migration/V8__Alter_column_i_size.sql
+++ b/resources/db/migration/V8__Alter_column_i_size.sql
@@ -1,0 +1,3 @@
+-- enlarge possible uploaded image size on upload
+ALTER TABLE images
+    ALTER COLUMN i_size TYPE BIGINT USING i_size::bigint;

--- a/resources/db/migration/V8__Alter_column_i_size.sql
+++ b/resources/db/migration/V8__Alter_column_i_size.sql
@@ -1,3 +1,3 @@
 -- enlarge possible uploaded image size on upload
-ALTER TABLE images
+ALTER TABLE zp_data.images
     ALTER COLUMN i_size TYPE BIGINT USING i_size::bigint;


### PR DESCRIPTION
fix: #157

Alters column `zp_data.images.i_size` to BIGINT ( including `USING` ). 

[Modifying Tables postgres tables](https://www.postgresql.org/docs/9.4/static/ddl-alter.html) mentions :

> This will succeed only if each existing entry in the column can be converted to the new type by an implicit cast. If a more complex conversion is needed, you can add a USING clause that specifies how to compute the new values from the old.

See also [postgresql change column type](http://www.postgresqltutorial.com/postgresql-change-column-type/).

I am not sure if **INT** -> **BIGINT** conversion is complex, however the PR uses `USING` because I did not find resources reporting `USING` hurts.

If approved, the migration run should be scheduled with respect to customer usage.