### PR TITLE
Support HEAD /v2/<team>/<artifact>/manifests/<name>

### DIFF
--- a/resources/api/pierone-api.yaml
+++ b/resources/api/pierone-api.yaml
@@ -281,6 +281,21 @@ paths:
       responses:
         "200":
           description: OK
+    head:
+      summary: check for existing image manifest
+      tags:
+        - Docker Registry API v2
+      operationId: org.zalando.stups.pierone.api-v2/head-manifest
+      security:         # remove for HTTP_ALLOW_PUBLIC_READ
+        - oauth2: [uid] # remove for HTTP_ALLOW_PUBLIC_READ
+        - iid:          # remove for HTTP_ALLOW_PUBLIC_READ
+      parameters:
+        - $ref: '#/parameters/team'
+        - $ref: '#/parameters/artifact'
+        - $ref: '#/parameters/name'
+      responses:
+        "200":
+          description: OK
   /v2/{team}/{artifact}/tags/list:
     get:
       summary: list tags

--- a/test/org/zalando/stups/pierone/v2_test.clj
+++ b/test/org/zalando/stups/pierone/v2_test.clj
@@ -212,6 +212,9 @@
         (is (= "application/vnd.docker.container.image.v1+json"
                (get-in response [:body :config :mediaType]))))
 
+      (expect 200
+              (client/head (u/v2-url "/myteam/myart/manifests/2.0-SNAPSHOT")
+                           (u/http-opts)))
 
       ; stop
       (component/stop system))))


### PR DESCRIPTION
This adds support for responding to `HEAD /v2/<team>/<artifact>/manifests/<name>` requests.
This is required by containerd and described in the opencontainers spec: https://github.com/opencontainers/distribution-spec/blob/master/spec.md#existing-manifests

Reference: https://github.com/containerd/cri/issues/787

I need this to pull skipper in my own Kubernetes cluster running containerd instead of docker :P